### PR TITLE
Compatibility with newer versions and hyprpm

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -1,0 +1,11 @@
+[repository]
+name = "hyprWorkspaceLayouts"
+authors = ["Zakk"]
+
+[hyprWorkspaceLayouts]
+description = "Workspace Specific Layouts"
+authors = ["Zakk"]
+output = "workspaceLayoutPlugin.so"
+build = [
+    "make all"
+]

--- a/main.cpp
+++ b/main.cpp
@@ -93,21 +93,25 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	g_pCreateWorkspaceHook->hook();
 
 		static const auto ADDLAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "addLayout");
-		g_pCreateWorkspaceHook = HyprlandAPI::createFunctionHook(PHANDLE, ADDLAYOUTMETHODS[0].address, (void *)&hkAddLayout);
-	g_pCreateWorkspaceHook->hook();
+		g_pAddLayoutHook = HyprlandAPI::createFunctionHook(PHANDLE, ADDLAYOUTMETHODS[0].address, (void *)&hkAddLayout);
+	g_pAddLayoutHook->hook();
 
 		static const auto REMOVELAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "removeLayout");
-		g_pCreateWorkspaceHook = HyprlandAPI::createFunctionHook(PHANDLE, REMOVELAYOUTMETHODS[0].address, (void *)&hkRemoveLayout);
-	g_pCreateWorkspaceHook->hook();
+		g_pRemoveLayoutHook = HyprlandAPI::createFunctionHook(PHANDLE, REMOVELAYOUTMETHODS[0].address, (void *)&hkRemoveLayout);
+	g_pRemoveLayoutHook->hook();
 
 		
 		HyprlandAPI::registerCallbackDynamic(PHANDLE, "preConfigReload", [&](void *self, SCallbackInfo&, std::any data) {WSConfigPreload();});
 
 		HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void *self, SCallbackInfo&, std::any data) {WSConfigReloaded();});
 		g_pWorkspaceLayout = std::make_unique<CWorkspaceLayout>();
+
+        // set default layout, because that will be used by the calls below, when adding itself as a layout or loading the config
+        g_pWorkspaceLayout->setDefaultLayout("dwindle");
+
 		HyprlandAPI::addLayout(PHANDLE, "workspacelayout", g_pWorkspaceLayout.get());
-		HyprlandAPI::reloadConfig();
-		
+		HyprlandAPI::reloadConfig(); // here the actual default layout will be read
+
     return {"Workspace layouts", "Per-workspace layouts", "Zakk", "1.0"};
 }
 

--- a/workspaceLayout.cpp
+++ b/workspaceLayout.cpp
@@ -357,7 +357,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 		if (w.workspaceID == ws) {
 			if (w.layout) {
 				for (auto &win : g_pCompositor->m_vWindows) {
-					if ((win->m_iWorkspaceID != ws) || !win->m_bMappedX11 || !win->m_bIsMapped || win->isHidden())
+					if ((win->m_iWorkspaceID != ws) || !win->m_bIsMapped || win->isHidden())
 						continue;
 					w.layout->onWindowRemoved(win.get());
 				}
@@ -366,7 +366,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 			w.layout = layout;
 			w.isDefault = isDefault;
 			for (auto &win : g_pCompositor->m_vWindows) {
-				if ((win->m_iWorkspaceID != ws) || !win->m_bMappedX11 || !win->m_bIsMapped || win->isHidden())
+				if ((win->m_iWorkspaceID != ws) || !win->m_bIsMapped || win->isHidden())
 					continue;
 				w.layout->onWindowCreated(win.get());
 			}
@@ -379,7 +379,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 	WSENTRY->layout = layout;
 	WSENTRY->isDefault = isDefault;
 	for (auto &win : g_pCompositor->m_vWindows) {
-		if ((win->m_iWorkspaceID != ws) || !win->m_bMappedX11 || !win->m_bIsMapped || win->isHidden())
+		if ((win->m_iWorkspaceID != ws) || !win->m_bIsMapped || win->isHidden())
 			continue;
 		WSENTRY->layout->onWindowCreated(win.get());
 	}


### PR DESCRIPTION
Currently this plugin is not really compatible with a recent Hyprland build. I've changed a few things to make it build and work again:
- Loading the plugin would cause a crash. This was because `CWorkspaceLayout::m_pDefaultLayout` was used whilst it was not yet assigned. Depending on the configuration, it would already be used during the configuration load or directly when loading the plugin. I've fixed this by setting a temporary default layout before adding the plugin and reloading the config.
- Also, some of the hooks were seemingly assigned to the wrong variables (?), which also caused a nullpointer dereference on `hkAddLayout`. 
- Additionally, `CWindow::m_bMappedX11` was lately removed (see https://github.com/hyprwm/Hyprland/commit/9fd928e114d7f57ac03aa7430d9cba41843347de)

I also took the opportunity to add a `hyprpm.toml` file to support loading with the new `hyprpm` plugin manager. 