### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Do you wish you could run different window tiling layouts on individual workspac
 ## Using hyprpm, Hyprland's official plugin manager (recommended)
 1. Run `hyprpm add https://github.com/zakk4223/hyprWorkspaceLayouts` and wait for hyprpm to build the plugin.
 2. Run `hyprpm enable hyprWorkspaceLayouts`
+3. Add `exec-once = hyprpm reload -n` to your `hyprland.conf` to make sure the plugins are loaded into Hyprland at boot.*`-n` will make hyprpm send a notification if anything goes wrong (e.g. update needed)*
 
 
 ## Using [hyprload](https://github.com/Duckonaut/hyprload)


### PR DESCRIPTION
Simple adjustment to the `README.md` because without it, the plugins don't load at boot if you used `hyprpm`to install the plugin.

Add `exec-once = hyprpm reload -n` to the `hyprland.conf`
This is following the official documentation at : https://wiki.hyprland.org/Plugins/Using-Plugins/#hyprpm

I've also added the note that is present in the doc about `-n` so we get a notification if there's an issue of if we need to update.

Thanks for the plugin, I really appreciate it!