### PR TITLE
Handle moveWindowTo across layouts

### DIFF
--- a/workspaceLayout.cpp
+++ b/workspaceLayout.cpp
@@ -385,9 +385,18 @@ void CWorkspaceLayout::moveWindowTo(PHLWINDOW pWindow, const std::string& direct
 	if (!pWindow) return; //??
 	auto const WSID = pWindow->workspaceID();
 	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->moveWindowTo(pWindow, direction, silent);
+	if (layout) {
+		layout->moveWindowTo(pWindow, direction, silent);
 
+		auto const NEXTID = pWindow->workspaceID();
+		IHyprLayout *nextlayout = getLayoutForWorkspace(NEXTID);
+
+		// layout has changed -> readd
+		if (nextlayout && nextlayout != layout) {
+			layout->onWindowRemoved(pWindow);
+			nextlayout->onWindowCreated(pWindow);
+		}
+	}
 }
 
 void CWorkspaceLayout::alterSplitRatio(PHLWINDOW pWindow, float ratio, bool exact) {


### PR DESCRIPTION
I've quickly implemented a fix for #11. This solution lets the layout reposition the window, and checks afterwards whether the window has changed workspace (and so layouts). In these cases, the window is then just removed and re-added as discussed.

Tested on my system and seems to work reliably.

close #11 