### PR TITLE
rename plugin to for consistancy between hyprctl and hyprpm

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -101,7 +101,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 		static const auto REMOVELAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "removeLayout");
 		g_pRemoveLayoutHook = HyprlandAPI::createFunctionHook(PHANDLE, REMOVELAYOUTMETHODS[0].address, (void *)&hkRemoveLayout);
 		g_pRemoveLayoutHook->hook();
-    return {"Workspace layouts", "Per-workspace layouts", "Zakk", "1.0"};
+    return {"hyprWorkspaceLayouts", "Per-workspace layouts", "Zakk", "1.0"};
 }
 
 // Do NOT change this function.


### PR DESCRIPTION
fixes the issue where the plugin is unloaded and loaded very time you use hyprpm and with some versions causes hyprpm to crash prior to this fix.

https://github.com/hyprwm/Hyprland/commit/09581d32fd465c5c4ff868090369ee67516c38a9

Even after the fix this prevents redundant reloading of the plugin.
```
✔ Unloaded Workspace layouts
✔ Loaded hyprWorkspaceLayouts
```