### PR TITLE
fix build with window member name changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+AlignEscapedNewlines: Right
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 180
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IndentCaseLabels: true
+IndentWidth: 4
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Auto
+TabWidth: 4
+UseTab: Never
+
+AllowShortEnumsOnASingleLine: false
+
+BraceWrapping:
+  AfterEnum: false
+
+AlignConsecutiveDeclarations: AcrossEmptyLines
+
+NamespaceIndentation: All

--- a/main.cpp
+++ b/main.cpp
@@ -2,105 +2,98 @@
 #include <hyprland/src/Compositor.hpp>
 #include "workspaceLayout.hpp"
 
-
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <unistd.h>
 #include <thread>
 
 namespace {
-	inline std::unique_ptr<CWorkspaceLayout> g_pWorkspaceLayout; 
-  inline std::vector<IHyprLayout *> g_vLayoutList;
+    inline std::unique_ptr<CWorkspaceLayout> g_pWorkspaceLayout;
+    inline std::vector<IHyprLayout*>         g_vLayoutList;
 
-	
+    void                                     WSConfigPreload() {
+        g_pWorkspaceLayout->clearLayoutMaps();
+    }
 
-	void WSConfigPreload() {
-			g_pWorkspaceLayout->clearLayoutMaps();
-	}
-	
-	
-	void WSConfigReloaded() {
+    void WSConfigReloaded() {
 
-		
-		static auto* const DEFAULTLAYOUT = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:wslayout:default_layout")->getDataStaticPtr();
-		if (g_pWorkspaceLayout) {
-			g_pWorkspaceLayout->setDefaultLayout(*DEFAULTLAYOUT);
-		  g_pWorkspaceLayout->setupLayoutList();
-		}
-	}
-	
-	void WSWorkspaceCreated(PHLWORKSPACE pWorkspace) {
-		g_pWorkspaceLayout->setupWorkspace(pWorkspace);
-	}
-	
-	void WSLayoutsChanged() {
-	  g_pWorkspaceLayout->setupLayoutList();
-		g_pWorkspaceLayout->onEnable();
-	}
-	
-	inline CFunctionHook *g_pCreateWorkspaceHook = nullptr;
-	typedef PHLWORKSPACE(*origCreateWorkspace)(void *, const int&, const int&, const std::string&);
-	
-	PHLWORKSPACE hkCreateWorkspace(void *thisptr, const int& id, const int& monid, const std::string& name) {
-	
-		PHLWORKSPACE ret = (*(origCreateWorkspace)g_pCreateWorkspaceHook->m_pOriginal)(thisptr, id, monid, name);
-		WSWorkspaceCreated(ret);
-		return ret;
-	}
+        static auto* const DEFAULTLAYOUT = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:wslayout:default_layout")->getDataStaticPtr();
+        if (g_pWorkspaceLayout) {
+            g_pWorkspaceLayout->setDefaultLayout(*DEFAULTLAYOUT);
+            g_pWorkspaceLayout->setupLayoutList();
+        }
+    }
 
+    void WSWorkspaceCreated(PHLWORKSPACE pWorkspace) {
+        g_pWorkspaceLayout->setupWorkspace(pWorkspace);
+    }
 
-	inline CFunctionHook *g_pAddLayoutHook = nullptr;
-	typedef bool(*origAddLayout)(void *, const std::string&, IHyprLayout *layout); 
-	
-	bool hkAddLayout(void *thisptr, const std::string& name, IHyprLayout *layout) {
-	
-		bool ret = (*(origAddLayout)g_pAddLayoutHook->m_pOriginal)(thisptr, name, layout);
-		WSLayoutsChanged();
-		
-		return ret;
-	}
+    void WSLayoutsChanged() {
+        g_pWorkspaceLayout->setupLayoutList();
+        g_pWorkspaceLayout->onEnable();
+    }
 
-	inline CFunctionHook *g_pRemoveLayoutHook = nullptr;
-	typedef bool(*origRemoveLayout)(void *, IHyprLayout *layout); 
-	
-	bool hkRemoveLayout(void *thisptr, IHyprLayout *layout) {
-	
-		//If the layout is us, call onDisable. It should probably be done for every type of layout, but be safe
-		if (layout == (IHyprLayout *)g_pWorkspaceLayout.get()) {
-			layout->onDisable();
-		}
-		bool ret = (*(origRemoveLayout)g_pRemoveLayoutHook->m_pOriginal)(thisptr,layout);
-		WSLayoutsChanged();
-		return ret;
-	}
+    inline CFunctionHook* g_pCreateWorkspaceHook = nullptr;
+    typedef PHLWORKSPACE (*origCreateWorkspace)(void*, const int&, const int&, const std::string&);
+
+    PHLWORKSPACE hkCreateWorkspace(void* thisptr, const int& id, const int& monid, const std::string& name) {
+
+        PHLWORKSPACE ret = (*(origCreateWorkspace)g_pCreateWorkspaceHook->m_pOriginal)(thisptr, id, monid, name);
+        WSWorkspaceCreated(ret);
+        return ret;
+    }
+
+    inline CFunctionHook* g_pAddLayoutHook = nullptr;
+    typedef bool (*origAddLayout)(void*, const std::string&, IHyprLayout* layout);
+
+    bool hkAddLayout(void* thisptr, const std::string& name, IHyprLayout* layout) {
+
+        bool ret = (*(origAddLayout)g_pAddLayoutHook->m_pOriginal)(thisptr, name, layout);
+        WSLayoutsChanged();
+
+        return ret;
+    }
+
+    inline CFunctionHook* g_pRemoveLayoutHook = nullptr;
+    typedef bool (*origRemoveLayout)(void*, IHyprLayout* layout);
+
+    bool hkRemoveLayout(void* thisptr, IHyprLayout* layout) {
+
+        //If the layout is us, call onDisable. It should probably be done for every type of layout, but be safe
+        if (layout == (IHyprLayout*)g_pWorkspaceLayout.get()) {
+            layout->onDisable();
+        }
+        bool ret = (*(origRemoveLayout)g_pRemoveLayoutHook->m_pOriginal)(thisptr, layout);
+        WSLayoutsChanged();
+        return ret;
+    }
 }
-
 
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:wslayout:default_layout", Hyprlang::STRING{"dwindle"});
-	  HyprlandAPI::addConfigValue(PHANDLE, "plugin:wslayout:layouts", Hyprlang::STRING(""));
-	  
-		static const auto WSCREATEMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "createNewWorkspace");
-		g_pCreateWorkspaceHook = HyprlandAPI::createFunctionHook(PHANDLE, WSCREATEMETHODS[0].address, (void *)&hkCreateWorkspace);
-	g_pCreateWorkspaceHook->hook();
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:wslayout:default_layout", Hyprlang::STRING{"dwindle"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:wslayout:layouts", Hyprlang::STRING(""));
 
-		static auto PCRCB = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preConfigReload", [&](void *self, SCallbackInfo&, std::any data) {WSConfigPreload();});
+    static const auto WSCREATEMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "createNewWorkspace");
+    g_pCreateWorkspaceHook            = HyprlandAPI::createFunctionHook(PHANDLE, WSCREATEMETHODS[0].address, (void*)&hkCreateWorkspace);
+    g_pCreateWorkspaceHook->hook();
 
-		static auto CRCB = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void *self, SCallbackInfo&, std::any data) {WSConfigReloaded();});
-		g_pWorkspaceLayout = std::make_unique<CWorkspaceLayout>();
-		HyprlandAPI::addLayout(PHANDLE, "workspacelayout", g_pWorkspaceLayout.get());
-		//Always set a default layout. It is possible other layouts are added before the reload config ticks.
-		g_pWorkspaceLayout->setDefaultLayout("dwindle");
-		HyprlandAPI::reloadConfig();
-		
-		static const auto ADDLAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "addLayout");
-		g_pAddLayoutHook = HyprlandAPI::createFunctionHook(PHANDLE, ADDLAYOUTMETHODS[0].address, (void *)&hkAddLayout);
-		g_pAddLayoutHook->hook();
+    static auto PCRCB = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo&, std::any data) { WSConfigPreload(); });
 
-		static const auto REMOVELAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "removeLayout");
-		g_pRemoveLayoutHook = HyprlandAPI::createFunctionHook(PHANDLE, REMOVELAYOUTMETHODS[0].address, (void *)&hkRemoveLayout);
-		g_pRemoveLayoutHook->hook();
+    static auto CRCB   = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void* self, SCallbackInfo&, std::any data) { WSConfigReloaded(); });
+    g_pWorkspaceLayout = std::make_unique<CWorkspaceLayout>();
+    HyprlandAPI::addLayout(PHANDLE, "workspacelayout", g_pWorkspaceLayout.get());
+    //Always set a default layout. It is possible other layouts are added before the reload config ticks.
+    g_pWorkspaceLayout->setDefaultLayout("dwindle");
+    HyprlandAPI::reloadConfig();
+
+    static const auto ADDLAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "addLayout");
+    g_pAddLayoutHook                   = HyprlandAPI::createFunctionHook(PHANDLE, ADDLAYOUTMETHODS[0].address, (void*)&hkAddLayout);
+    g_pAddLayoutHook->hook();
+
+    static const auto REMOVELAYOUTMETHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "removeLayout");
+    g_pRemoveLayoutHook                   = HyprlandAPI::createFunctionHook(PHANDLE, REMOVELAYOUTMETHODS[0].address, (void*)&hkRemoveLayout);
+    g_pRemoveLayoutHook->hook();
     return {"hyprWorkspaceLayouts", "Per-workspace layouts", "Zakk", "1.0"};
 }
 

--- a/workspaceLayout.cpp
+++ b/workspaceLayout.cpp
@@ -1,266 +1,276 @@
 #include "workspaceLayout.hpp"
 
-
 SWorkspaceLayoutWindowData* CWorkspaceLayout::getDataFromWindow(PHLWINDOW pWindow, bool create) {
     for (auto& nd : m_vWorkspaceWindowData) {
         if (nd.pWindow.lock() == pWindow) {
             return &nd;
-				}
+        }
     }
 
-		//Create it if we don't have it, using the window's current workspaceID.
-		SWorkspaceLayoutWindowData *WINDOWDATA = nullptr;
-		if (create) {
-	 		WINDOWDATA = &m_vWorkspaceWindowData.emplace_back();
-			WINDOWDATA->pWindow = pWindow;
-			WINDOWDATA->workspaceID = pWindow->workspaceID();
-		}
-		return WINDOWDATA;
+    //Create it if we don't have it, using the window's current workspaceID.
+    SWorkspaceLayoutWindowData* WINDOWDATA = nullptr;
+    if (create) {
+        WINDOWDATA              = &m_vWorkspaceWindowData.emplace_back();
+        WINDOWDATA->pWindow     = pWindow;
+        WINDOWDATA->workspaceID = pWindow->workspaceID();
+    }
+    return WINDOWDATA;
 }
 
 void CWorkspaceLayout::setupWorkspace(PHLWORKSPACE pWorkspace) {
-	if (!pWorkspace) {
-		//??
-		return;
-	}
-	IHyprLayout *wlret = nullptr;
-	wlret = findUserLayoutForWorkspace(pWorkspace);
-	bool isDefault = false;
-	if (!wlret) {
-			isDefault = true;
-			wlret = m_pDefaultLayout;
-	}
- 	setLayoutForWorkspace(wlret, pWorkspace, isDefault);
+    if (!pWorkspace) {
+        //??
+        return;
+    }
+    IHyprLayout* wlret = nullptr;
+    wlret              = findUserLayoutForWorkspace(pWorkspace);
+    bool isDefault     = false;
+    if (!wlret) {
+        isDefault = true;
+        wlret     = m_pDefaultLayout;
+    }
+    setLayoutForWorkspace(wlret, pWorkspace, isDefault);
 }
 void CWorkspaceLayout::onEnable() {
 
-	for (auto &wsp : g_pCompositor->m_workspaces) {
-		setupWorkspace(wsp);
-	}
+    for (auto& wsp : g_pCompositor->m_workspaces) {
+        setupWorkspace(wsp);
+    }
 }
 
 void CWorkspaceLayout::onDisable() {
 
-	for (auto &wsd : m_vWorkspacesData) {
-		if (wsd.layout) {
-			wsd.layout->onDisable();
-		}
-	}
-	m_vWorkspacesData.clear();
+    for (auto& wsd : m_vWorkspacesData) {
+        if (wsd.layout) {
+            wsd.layout->onDisable();
+        }
+    }
+    m_vWorkspacesData.clear();
 }
 
 void CWorkspaceLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
 
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow);
-	if (!WDATA) return;
-	auto const WSID = WDATA->workspaceID;
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		return layout->onWindowCreated(pWindow, direction);
-	}
-
+    if (!pWindow)
+        return; //??
+    auto WDATA = getDataFromWindow(pWindow);
+    if (!WDATA)
+        return;
+    auto const   WSID   = WDATA->workspaceID;
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        return layout->onWindowCreated(pWindow, direction);
+    }
 }
 
-
 void CWorkspaceLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection direction) {
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow);
-	if (!WDATA) return;
-	auto const WSID = WDATA->workspaceID;
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		layout->onWindowCreatedTiling(pWindow, direction);
-	}
+    if (!pWindow)
+        return; //??
+    auto WDATA = getDataFromWindow(pWindow);
+    if (!WDATA)
+        return;
+    auto const   WSID   = WDATA->workspaceID;
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        layout->onWindowCreatedTiling(pWindow, direction);
+    }
 }
 
 void CWorkspaceLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow);
-	if (!WDATA) return;
-	auto const WSID = WDATA->workspaceID;
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		return layout->onWindowCreatedFloating(pWindow);
-	}
+    if (!pWindow)
+        return; //??
+    auto WDATA = getDataFromWindow(pWindow);
+    if (!WDATA)
+        return;
+    auto const   WSID   = WDATA->workspaceID;
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        return layout->onWindowCreatedFloating(pWindow);
+    }
 }
 
 bool CWorkspaceLayout::isWindowTiled(PHLWINDOW pWindow) {
-	if (!pWindow) return false; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->isWindowTiled(pWindow);
-	return false;
+    if (!pWindow)
+        return false; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->isWindowTiled(pWindow);
+    return false;
 }
 
-
 void CWorkspaceLayout::onWindowRemoved(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow, false);
-	auto const WSID = WDATA ? WDATA->workspaceID : pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		if (WDATA) //??
-			m_vWorkspaceWindowData.remove(*WDATA);
-		return layout->onWindowRemoved(pWindow);
-	}
-
+    if (!pWindow)
+        return; //??
+    auto         WDATA  = getDataFromWindow(pWindow, false);
+    auto const   WSID   = WDATA ? WDATA->workspaceID : pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        if (WDATA) //??
+            m_vWorkspaceWindowData.remove(*WDATA);
+        return layout->onWindowRemoved(pWindow);
+    }
 }
 
 void CWorkspaceLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow, false);
-	auto const WSID = WDATA ? WDATA->workspaceID : pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-	{
-		if (WDATA) //??
-			m_vWorkspaceWindowData.remove(*WDATA);
+    if (!pWindow)
+        return; //??
+    auto         WDATA  = getDataFromWindow(pWindow, false);
+    auto const   WSID   = WDATA ? WDATA->workspaceID : pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        if (WDATA) //??
+            m_vWorkspaceWindowData.remove(*WDATA);
 
-		layout->onWindowRemovedTiling(pWindow);
-	}
-
+        layout->onWindowRemovedTiling(pWindow);
+    }
 }
 
 void CWorkspaceLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto WDATA = getDataFromWindow(pWindow, false);
-	if (WDATA) return;
-	auto const WSID = WDATA->workspaceID;
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		if (WDATA) //??
-			m_vWorkspaceWindowData.remove(*WDATA);
-		return layout->onWindowRemovedFloating(pWindow);
-	}
-
+    if (!pWindow)
+        return; //??
+    auto WDATA = getDataFromWindow(pWindow, false);
+    if (WDATA)
+        return;
+    auto const   WSID   = WDATA->workspaceID;
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        if (WDATA) //??
+            m_vWorkspaceWindowData.remove(*WDATA);
+        return layout->onWindowRemovedFloating(pWindow);
+    }
 }
 
 void CWorkspaceLayout::recalculateMonitor(const MONITORID& monID) {
-	const auto PMONITOR = g_pCompositor->getMonitorFromID(monID);
-	if (!PMONITOR)
-		return;
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(monID);
+    if (!PMONITOR)
+        return;
 
-	if (PMONITOR->activeSpecialWorkspace) {
-		const auto PSPWS = PMONITOR->activeSpecialWorkspace;
-		if (PSPWS) {
-			IHyprLayout *layout = getLayoutForWorkspace(PSPWS->m_id);
-			if (layout)
-				return layout->recalculateMonitor(monID);
-		}
-	}
-	const auto PWORKSPACE = PMONITOR->activeWorkspace;
-	if (!PWORKSPACE) return;
-	IHyprLayout *layout = getLayoutForWorkspace(PWORKSPACE->m_id);
-	if (layout)
-		return layout->recalculateMonitor(monID);
+    if (PMONITOR->activeSpecialWorkspace) {
+        const auto PSPWS = PMONITOR->activeSpecialWorkspace;
+        if (PSPWS) {
+            IHyprLayout* layout = getLayoutForWorkspace(PSPWS->m_id);
+            if (layout)
+                return layout->recalculateMonitor(monID);
+        }
+    }
+    const auto PWORKSPACE = PMONITOR->activeWorkspace;
+    if (!PWORKSPACE)
+        return;
+    IHyprLayout* layout = getLayoutForWorkspace(PWORKSPACE->m_id);
+    if (layout)
+        return layout->recalculateMonitor(monID);
 }
 
 void CWorkspaceLayout::recalculateWindow(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->recalculateWindow(pWindow);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->recalculateWindow(pWindow);
 }
 
 void CWorkspaceLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->changeWindowFloatingMode(pWindow);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->changeWindowFloatingMode(pWindow);
 }
 
 void CWorkspaceLayout::onBeginDragWindow() {
-  const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-        	layout->onBeginDragWindow();
+    const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        layout->onBeginDragWindow();
 
-        	m_vBeginDragXY = layout->m_vBeginDragXY;
-        	m_vBeginDragPositionXY = layout->m_vBeginDragPositionXY;
-        	m_vBeginDragSizeXY = layout->m_vBeginDragSizeXY;
-        	m_vLastDragXY = layout->m_vLastDragXY;
-        	m_vDraggingWindowOriginalFloatSize = layout->m_vDraggingWindowOriginalFloatSize;
-        	m_eGrabbedCorner = layout->m_eGrabbedCorner;
-    	}
+        m_vBeginDragXY                     = layout->m_vBeginDragXY;
+        m_vBeginDragPositionXY             = layout->m_vBeginDragPositionXY;
+        m_vBeginDragSizeXY                 = layout->m_vBeginDragSizeXY;
+        m_vLastDragXY                      = layout->m_vLastDragXY;
+        m_vDraggingWindowOriginalFloatSize = layout->m_vDraggingWindowOriginalFloatSize;
+        m_eGrabbedCorner                   = layout->m_eGrabbedCorner;
+    }
 }
 
 void CWorkspaceLayout::resizeActiveWindow(const Vector2D& vec, eRectCorner corner, PHLWINDOW pWindow) {
-	const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
-	if (!validMapped(PWINDOW)) return; //??
-	auto const WSID = PWINDOW->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->resizeActiveWindow(vec, corner, PWINDOW);
-
+    const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
+    if (!validMapped(PWINDOW))
+        return; //??
+    auto const   WSID   = PWINDOW->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->resizeActiveWindow(vec, corner, PWINDOW);
 }
 
 void CWorkspaceLayout::moveActiveWindow(const Vector2D& vec, PHLWINDOW pWindow) {
-	const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
-	if (!validMapped(PWINDOW)) return; //??
-	auto const WSID = PWINDOW->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->moveActiveWindow(vec, PWINDOW);
-
+    const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
+    if (!validMapped(PWINDOW))
+        return; //??
+    auto const   WSID   = PWINDOW->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->moveActiveWindow(vec, PWINDOW);
 }
 
 void CWorkspaceLayout::onEndDragWindow() {
 
-  const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
-	if (!validMapped(pWindow)) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
+    const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
+    if (!validMapped(pWindow))
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
 
-	if (layout) {
-        	layout->m_vBeginDragXY = m_vBeginDragXY;
-        	layout->m_vBeginDragPositionXY = m_vBeginDragPositionXY;
-        	layout->m_vBeginDragSizeXY = m_vBeginDragSizeXY;
-        	layout->m_vLastDragXY = m_vLastDragXY;
-        	layout->m_vDraggingWindowOriginalFloatSize = m_vDraggingWindowOriginalFloatSize;
-        	layout->m_eGrabbedCorner = m_eGrabbedCorner;
+    if (layout) {
+        layout->m_vBeginDragXY                     = m_vBeginDragXY;
+        layout->m_vBeginDragPositionXY             = m_vBeginDragPositionXY;
+        layout->m_vBeginDragSizeXY                 = m_vBeginDragSizeXY;
+        layout->m_vLastDragXY                      = m_vLastDragXY;
+        layout->m_vDraggingWindowOriginalFloatSize = m_vDraggingWindowOriginalFloatSize;
+        layout->m_eGrabbedCorner                   = m_eGrabbedCorner;
 
-        	layout->onEndDragWindow();
-					auto WDATA = getDataFromWindow(pWindow);
-					if (WDATA) {
-							//The layout's onEndDragWindow called onWindowCreatedTiling internally. Update our map to reflect the new workspace for the window)
-							WDATA->workspaceID = WSID;
-					}
-    	}
+        layout->onEndDragWindow();
+        auto WDATA = getDataFromWindow(pWindow);
+        if (WDATA) {
+            //The layout's onEndDragWindow called onWindowCreatedTiling internally. Update our map to reflect the new workspace for the window)
+            WDATA->workspaceID = WSID;
+        }
+    }
 }
 
 void CWorkspaceLayout::onMouseMove(const Vector2D& vec) {
-  const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
-	if (!validMapped(pWindow)) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
+    const auto pWindow = g_pInputManager->currentlyDraggedWindow.lock();
+    if (!validMapped(pWindow))
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
 
-	if (layout) {
-        	layout->m_vBeginDragXY = m_vBeginDragXY;
-        	layout->m_vBeginDragPositionXY = m_vBeginDragPositionXY;
-        	layout->m_vBeginDragSizeXY = m_vBeginDragSizeXY;
-        	layout->m_vLastDragXY = m_vLastDragXY;
-        	layout->m_vDraggingWindowOriginalFloatSize = m_vDraggingWindowOriginalFloatSize;
-        	layout->m_eGrabbedCorner = m_eGrabbedCorner;
+    if (layout) {
+        layout->m_vBeginDragXY                     = m_vBeginDragXY;
+        layout->m_vBeginDragPositionXY             = m_vBeginDragPositionXY;
+        layout->m_vBeginDragSizeXY                 = m_vBeginDragSizeXY;
+        layout->m_vLastDragXY                      = m_vLastDragXY;
+        layout->m_vDraggingWindowOriginalFloatSize = m_vDraggingWindowOriginalFloatSize;
+        layout->m_eGrabbedCorner                   = m_eGrabbedCorner;
 
-        	layout->onMouseMove(vec);
+        layout->onMouseMove(vec);
 
-        	m_vLastDragXY = layout->m_vLastDragXY;
-    	}
+        m_vLastDragXY = layout->m_vLastDragXY;
+    }
 }
 
 void CWorkspaceLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->fullscreenRequestForWindow(pWindow, CURRENT_EFFECTIVE_MODE, EFFECTIVE_MODE);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->fullscreenRequestForWindow(pWindow, CURRENT_EFFECTIVE_MODE, EFFECTIVE_MODE);
 }
 
 std::any CWorkspaceLayout::layoutMessage(SLayoutMessageHeader header, std::string message) {
@@ -271,327 +281,319 @@ std::any CWorkspaceLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         return 0;
     }
 
-    auto command = vars[0];
+    auto       command = vars[0];
 
-		const auto PWINDOW = header.pWindow;
-		auto const WSID = PWINDOW->workspaceID();
-		if (command == "setlayout" && (vars.size() == 2)) {
-			IHyprLayout *layout = getLayoutByName(vars[1]);
-			if (layout) {
-				setLayoutForWorkspace(layout, WSID);
-			}
-			return 0;
-	  } else if (command == "cyclelayout") {
-		  size_t layoutidx = 0;
+    const auto PWINDOW = header.pWindow;
+    auto const WSID    = PWINDOW->workspaceID();
+    if (command == "setlayout" && (vars.size() == 2)) {
+        IHyprLayout* layout = getLayoutByName(vars[1]);
+        if (layout) {
+            setLayoutForWorkspace(layout, WSID);
+        }
+        return 0;
+    } else if (command == "cyclelayout") {
+        size_t       layoutidx = 0;
 
-		  IHyprLayout *wslayout = getLayoutForWorkspace(WSID);
+        IHyprLayout* wslayout = getLayoutForWorkspace(WSID);
 
-		  for(size_t i = 0; i < m_vLayoutList.size(); i++) {
-			    if (m_vLayoutList[i] == wslayout) {
-				      layoutidx = i;
-				      break;
-			    }
-	  	}
-		  if (vars.size() == 1 || vars[1].contains("next")) {
-        layoutidx++;
-			} else if (vars.size() == 2 && vars[1].contains("prev")) {
-			  if (layoutidx == 0)
-			    layoutidx = m_vLayoutList.size()-1;
-			  else
-			    layoutidx--;
-			}
+        for (size_t i = 0; i < m_vLayoutList.size(); i++) {
+            if (m_vLayoutList[i] == wslayout) {
+                layoutidx = i;
+                break;
+            }
+        }
+        if (vars.size() == 1 || vars[1].contains("next")) {
+            layoutidx++;
+        } else if (vars.size() == 2 && vars[1].contains("prev")) {
+            if (layoutidx == 0)
+                layoutidx = m_vLayoutList.size() - 1;
+            else
+                layoutidx--;
+        }
 
-		  if (layoutidx >= m_vLayoutList.size())
-		     layoutidx = 0;
-		  IHyprLayout *newLayout = m_vLayoutList[layoutidx];
-		  if (newLayout)
-		      setLayoutForWorkspace(newLayout, WSID);
-	  } else if (command == "togglelayout") {
-		  IHyprLayout *prevLayout = getPreviousLayoutForWorkspace(WSID);
-		  IHyprLayout *currLayout = getLayoutForWorkspace(WSID);
-		  IHyprLayout *newLayout = nullptr;
-		  if (vars.size() == 2) {
-		    newLayout = getLayoutByName(vars[1]);
-			  if (newLayout) {
-				    if (newLayout == currLayout)
-				      setLayoutForWorkspace(prevLayout, WSID);
-				    else
-				      setLayoutForWorkspace(newLayout, WSID);
-		    }
-			} else {
-	      setLayoutForWorkspace(prevLayout, WSID);
-	    }
-		} else {
-			IHyprLayout *layout = getLayoutForWorkspace(WSID);
-			if (layout)
-				return layout->layoutMessage(header, message);
-		}
+        if (layoutidx >= m_vLayoutList.size())
+            layoutidx = 0;
+        IHyprLayout* newLayout = m_vLayoutList[layoutidx];
+        if (newLayout)
+            setLayoutForWorkspace(newLayout, WSID);
+    } else if (command == "togglelayout") {
+        IHyprLayout* prevLayout = getPreviousLayoutForWorkspace(WSID);
+        IHyprLayout* currLayout = getLayoutForWorkspace(WSID);
+        IHyprLayout* newLayout  = nullptr;
+        if (vars.size() == 2) {
+            newLayout = getLayoutByName(vars[1]);
+            if (newLayout) {
+                if (newLayout == currLayout)
+                    setLayoutForWorkspace(prevLayout, WSID);
+                else
+                    setLayoutForWorkspace(newLayout, WSID);
+            }
+        } else {
+            setLayoutForWorkspace(prevLayout, WSID);
+        }
+    } else {
+        IHyprLayout* layout = getLayoutForWorkspace(WSID);
+        if (layout)
+            return layout->layoutMessage(header, message);
+    }
 
-	return 0;
+    return 0;
 }
 
-
 SWindowRenderLayoutHints CWorkspaceLayout::requestRenderHints(PHLWINDOW pWindow) {
-	SWindowRenderLayoutHints hints;
-	if (!pWindow) return hints; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->requestRenderHints(pWindow);
-	return hints;
+    SWindowRenderLayoutHints hints;
+    if (!pWindow)
+        return hints; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->requestRenderHints(pWindow);
+    return hints;
 }
 
 Vector2D CWorkspaceLayout::predictSizeForNewWindowTiled() {
-	if (!g_pCompositor->m_lastMonitor)
-		return {};
-	auto const WSID = g_pCompositor->m_lastMonitor->activeWorkspace->m_id;
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->predictSizeForNewWindowTiled();
-	return {};
+    if (!g_pCompositor->m_lastMonitor)
+        return {};
+    auto const   WSID   = g_pCompositor->m_lastMonitor->activeWorkspace->m_id;
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->predictSizeForNewWindowTiled();
+    return {};
 }
 
 void CWorkspaceLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
 
-	if (!pWindow || !pWindow2) return; //??
-	auto const WSID1 = pWindow->workspaceID();
-	auto const WSID2 = pWindow2->workspaceID();
+    if (!pWindow || !pWindow2)
+        return; //??
+    auto const   WSID1 = pWindow->workspaceID();
+    auto const   WSID2 = pWindow2->workspaceID();
 
-	IHyprLayout *layout1 = getLayoutForWorkspace(WSID1);
-	IHyprLayout *layout2 = getLayoutForWorkspace(WSID2);
+    IHyprLayout* layout1 = getLayoutForWorkspace(WSID1);
+    IHyprLayout* layout2 = getLayoutForWorkspace(WSID2);
 
-	if (layout1 == layout2)
-		return layout1->switchWindows(pWindow, pWindow2);
+    if (layout1 == layout2)
+        return layout1->switchWindows(pWindow, pWindow2);
 
-	//Different layouts; hax
+    //Different layouts; hax
 
-	std::swap(pWindow2->m_monitor, pWindow->m_monitor);
-	std::swap(pWindow2->m_workspace, pWindow->m_workspace);
+    std::swap(pWindow2->m_monitor, pWindow->m_monitor);
+    std::swap(pWindow2->m_workspace, pWindow->m_workspace);
 
+    pWindow->setAnimationsToMove();
+    pWindow2->setAnimationsToMove();
 
-	pWindow->setAnimationsToMove();
-	pWindow2->setAnimationsToMove();
+    layout1->replaceWindowDataWith(pWindow, pWindow2);
+    layout2->replaceWindowDataWith(pWindow2, pWindow);
+    recalculateMonitor(pWindow->monitorID());
+    recalculateMonitor(pWindow2->monitorID());
 
-	layout1->replaceWindowDataWith(pWindow, pWindow2);
-	layout2->replaceWindowDataWith(pWindow2, pWindow);
-  recalculateMonitor(pWindow->monitorID());
-	recalculateMonitor(pWindow2->monitorID());
-
-  g_pHyprRenderer->damageWindow(pWindow);
-  g_pHyprRenderer->damageWindow(pWindow2);
+    g_pHyprRenderer->damageWindow(pWindow);
+    g_pHyprRenderer->damageWindow(pWindow2);
 }
 
 void CWorkspaceLayout::moveWindowTo(PHLWINDOW pWindow, const std::string& direction, bool silent) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout) {
-		layout->moveWindowTo(pWindow, direction, silent);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout) {
+        layout->moveWindowTo(pWindow, direction, silent);
 
-		auto const NEXTID = pWindow->workspaceID();
-		IHyprLayout *nextlayout = getLayoutForWorkspace(NEXTID);
+        auto const   NEXTID     = pWindow->workspaceID();
+        IHyprLayout* nextlayout = getLayoutForWorkspace(NEXTID);
 
-		// layout has changed -> readd
-		if (nextlayout && nextlayout != layout) {
-			layout->onWindowRemoved(pWindow);
-			nextlayout->onWindowCreated(pWindow);
-		}
-	}
+        // layout has changed -> readd
+        if (nextlayout && nextlayout != layout) {
+            layout->onWindowRemoved(pWindow);
+            nextlayout->onWindowCreated(pWindow);
+        }
+    }
 }
 
 void CWorkspaceLayout::alterSplitRatio(PHLWINDOW pWindow, float ratio, bool exact) {
 
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->alterSplitRatio(pWindow, ratio, exact);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->alterSplitRatio(pWindow, ratio, exact);
 }
 
 std::string CWorkspaceLayout::getLayoutName() {
-	return "WSLayout";
+    return "WSLayout";
 }
 
 PHLWINDOW CWorkspaceLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
-	if (!pWindow) return nullptr; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->getNextWindowCandidate(pWindow);
-	return nullptr;
-
+    if (!pWindow)
+        return nullptr; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->getNextWindowCandidate(pWindow);
+    return nullptr;
 }
 
 void CWorkspaceLayout::onWindowFocusChange(PHLWINDOW pWindow) {
 
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->onWindowFocusChange(pWindow);
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->onWindowFocusChange(pWindow);
 }
 
 void CWorkspaceLayout::replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to) {
-	if (!from) return; //??
-	auto const WSID = from->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->replaceWindowDataWith(from, to);
-
+    if (!from)
+        return; //??
+    auto const   WSID   = from->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->replaceWindowDataWith(from, to);
 }
 
 bool CWorkspaceLayout::isWindowReachable(PHLWINDOW pWindow) {
-	if (!pWindow) return false; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->isWindowReachable(pWindow);
-	return false;
-
+    if (!pWindow)
+        return false; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->isWindowReachable(pWindow);
+    return false;
 }
 
 void CWorkspaceLayout::bringWindowToTop(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->bringWindowToTop(pWindow);
-
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->bringWindowToTop(pWindow);
 }
 
 void CWorkspaceLayout::requestFocusForWindow(PHLWINDOW pWindow) {
-	if (!pWindow) return; //??
-	auto const WSID = pWindow->workspaceID();
-	IHyprLayout *layout = getLayoutForWorkspace(WSID);
-	if (layout)
-		return layout->requestFocusForWindow(pWindow);
-
+    if (!pWindow)
+        return; //??
+    auto const   WSID   = pWindow->workspaceID();
+    IHyprLayout* layout = getLayoutForWorkspace(WSID);
+    if (layout)
+        return layout->requestFocusForWindow(pWindow);
 }
 
-
-IHyprLayout *CWorkspaceLayout::findUserLayoutForWorkspace(PHLWORKSPACE pWorkspace) {
-	std::string retName = "";
-		const auto wsrule = g_pConfigManager->getWorkspaceRuleFor(pWorkspace);
-		const auto layoutopts = wsrule.layoutopts;
-		if (layoutopts.contains("wslayout-layout")) {
-			retName = layoutopts.at("wslayout-layout");
-		}
-		return getLayoutByName(retName);
+IHyprLayout* CWorkspaceLayout::findUserLayoutForWorkspace(PHLWORKSPACE pWorkspace) {
+    std::string retName    = "";
+    const auto  wsrule     = g_pConfigManager->getWorkspaceRuleFor(pWorkspace);
+    const auto  layoutopts = wsrule.layoutopts;
+    if (layoutopts.contains("wslayout-layout")) {
+        retName = layoutopts.at("wslayout-layout");
+    }
+    return getLayoutByName(retName);
 }
 
+IHyprLayout* CWorkspaceLayout::getPreviousLayoutForWorkspace(const int& ws) {
 
-IHyprLayout *CWorkspaceLayout::getPreviousLayoutForWorkspace(const int &ws) {
-
-	for (auto& w : m_vWorkspacesData) {
-		if (w.workspaceID == ws && w.layout)
-		{
-			return w.previousLayout;
-		}
-	}
-	return nullptr;
+    for (auto& w : m_vWorkspacesData) {
+        if (w.workspaceID == ws && w.layout) {
+            return w.previousLayout;
+        }
+    }
+    return nullptr;
 }
 
-IHyprLayout *CWorkspaceLayout::getLayoutForWorkspace(const int &ws) {
+IHyprLayout* CWorkspaceLayout::getLayoutForWorkspace(const int& ws) {
 
-	for (auto& w : m_vWorkspacesData) {
-		if (w.workspaceID == ws && w.layout)
-		{
-			return w.layout;
-		}
-	}
-	return nullptr;
+    for (auto& w : m_vWorkspacesData) {
+        if (w.workspaceID == ws && w.layout) {
+            return w.layout;
+        }
+    }
+    return nullptr;
 }
 
+void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout* layout, PHLWORKSPACE pWorkspace, bool isDefault) {
 
-
-void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, PHLWORKSPACE pWorkspace, bool isDefault) {
-
-	setLayoutForWorkspace(layout, pWorkspace->m_id, isDefault);
+    setLayoutForWorkspace(layout, pWorkspace->m_id, isDefault);
 }
 
+void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout* layout, const int& ws, bool isDefault) {
+    if (!layout)
+        return;
+    if (layout->getLayoutName() == getLayoutName())
+        return;
 
+    for (auto& w : m_vWorkspacesData) {
+        if (w.workspaceID == ws) {
+            if (w.layout) {
+                for (auto& win : g_pCompositor->m_windows) {
+                    if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
+                        continue;
+                    w.layout->onWindowRemoved(win);
+                }
+            }
 
-void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws, bool isDefault) {
-	if (!layout)
-			return;
-	if (layout->getLayoutName() == getLayoutName())
-		return;
-
-	for (auto& w : m_vWorkspacesData) {
-		if (w.workspaceID == ws) {
-			if (w.layout) {
-				for (auto &win : g_pCompositor->m_windows) {
-					if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
-						continue;
-					w.layout->onWindowRemoved(win);
-				}
-			}
-
-		  if (w.layout)
-				w.previousLayout = w.layout;
-			w.layout = layout;
-			w.isDefault = isDefault;
-			for (auto &win : g_pCompositor->m_windows) {
-				if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
-					continue;
-				onWindowCreated(win);
-			}
-			return;
-		}
-	}
-	//Not found, create a new entry
-	const auto WSENTRY = &m_vWorkspacesData.emplace_back();
-	WSENTRY->workspaceID = ws;
-	WSENTRY->layout = layout;
-	WSENTRY->isDefault = isDefault;
-	for (auto &win : g_pCompositor->m_windows) {
-		if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
-			continue;
-		onWindowCreated(win);
-	}
+            if (w.layout)
+                w.previousLayout = w.layout;
+            w.layout    = layout;
+            w.isDefault = isDefault;
+            for (auto& win : g_pCompositor->m_windows) {
+                if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
+                    continue;
+                onWindowCreated(win);
+            }
+            return;
+        }
+    }
+    //Not found, create a new entry
+    const auto WSENTRY   = &m_vWorkspacesData.emplace_back();
+    WSENTRY->workspaceID = ws;
+    WSENTRY->layout      = layout;
+    WSENTRY->isDefault   = isDefault;
+    for (auto& win : g_pCompositor->m_windows) {
+        if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
+            continue;
+        onWindowCreated(win);
+    }
 }
 
 void CWorkspaceLayout::setDefaultLayout(std::string name) {
-	IHyprLayout *layout = getLayoutByName(name);
-	if (layout)
-	{
-		m_pDefaultLayout = layout;
-		for (auto& w : m_vWorkspacesData) {
-			if (w.isDefault) {
-				setLayoutForWorkspace(m_pDefaultLayout, w.workspaceID, true);
-			}
-		}
-	}
+    IHyprLayout* layout = getLayoutByName(name);
+    if (layout) {
+        m_pDefaultLayout = layout;
+        for (auto& w : m_vWorkspacesData) {
+            if (w.isDefault) {
+                setLayoutForWorkspace(m_pDefaultLayout, w.workspaceID, true);
+            }
+        }
+    }
 }
 
-
-IHyprLayout *CWorkspaceLayout::getLayoutByName(const std::string& name) {
-	for (auto &layoutp : g_pLayoutManager->m_vLayouts) {
-		if(layoutp.first == name) {
-			return layoutp.second;
-		}
-	}
-	return nullptr;
+IHyprLayout* CWorkspaceLayout::getLayoutByName(const std::string& name) {
+    for (auto& layoutp : g_pLayoutManager->m_vLayouts) {
+        if (layoutp.first == name) {
+            return layoutp.second;
+        }
+    }
+    return nullptr;
 }
 
-void CWorkspaceLayout::clearLayoutMaps() {
-}
+void CWorkspaceLayout::clearLayoutMaps() {}
 
 void CWorkspaceLayout::setupLayoutList() {
-		static auto* const LAYOUTS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:wslayout:layouts")->getDataStaticPtr();
-	  m_vLayoutList.clear();
-	  CVarList layoutlist(*LAYOUTS, 0, 's');
-	  for (size_t i = 0; i < layoutlist.size(); i++) {
-		    auto layoutName = layoutlist[i];
-		    IHyprLayout *layout = getLayoutByName(layoutName);
-		    if (layout && layout->getLayoutName() != getLayoutName())
-		        m_vLayoutList.push_back(layout);
-	  }
+    static auto* const LAYOUTS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:wslayout:layouts")->getDataStaticPtr();
+    m_vLayoutList.clear();
+    CVarList layoutlist(*LAYOUTS, 0, 's');
+    for (size_t i = 0; i < layoutlist.size(); i++) {
+        auto         layoutName = layoutlist[i];
+        IHyprLayout* layout     = getLayoutByName(layoutName);
+        if (layout && layout->getLayoutName() != getLayoutName())
+            m_vLayoutList.push_back(layout);
+    }
 
-	  if (!m_vLayoutList.size()) {
-        for (auto &layoutp : g_pLayoutManager->m_vLayouts) {
-		        if (layoutp.second->getLayoutName() != getLayoutName())
+    if (!m_vLayoutList.size()) {
+        for (auto& layoutp : g_pLayoutManager->m_vLayouts) {
+            if (layoutp.second->getLayoutName() != getLayoutName())
                 m_vLayoutList.push_back(layoutp.second);
-		    }
-	  }
+        }
+    }
 }

--- a/workspaceLayout.cpp
+++ b/workspaceLayout.cpp
@@ -365,8 +365,8 @@ void CWorkspaceLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
 
 	//Different layouts; hax
 
-	std::swap(pWindow2->m_pMonitor, pWindow->m_pMonitor);
-	std::swap(pWindow2->m_pWorkspace, pWindow->m_pWorkspace);
+	std::swap(pWindow2->m_monitor, pWindow->m_monitor);
+	std::swap(pWindow2->m_workspace, pWindow->m_workspace);
 
 
 	pWindow->setAnimationsToMove();
@@ -521,7 +521,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 		if (w.workspaceID == ws) {
 			if (w.layout) {
 				for (auto &win : g_pCompositor->m_windows) {
-					if ((win->workspaceID() != ws) || !win->m_bIsMapped || win->isHidden())
+					if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
 						continue;
 					w.layout->onWindowRemoved(win);
 				}
@@ -532,7 +532,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 			w.layout = layout;
 			w.isDefault = isDefault;
 			for (auto &win : g_pCompositor->m_windows) {
-				if ((win->workspaceID() != ws) || !win->m_bIsMapped || win->isHidden())
+				if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
 					continue;
 				onWindowCreated(win);
 			}
@@ -545,7 +545,7 @@ void CWorkspaceLayout::setLayoutForWorkspace(IHyprLayout *layout, const int& ws,
 	WSENTRY->layout = layout;
 	WSENTRY->isDefault = isDefault;
 	for (auto &win : g_pCompositor->m_windows) {
-		if ((win->workspaceID() != ws) || !win->m_bIsMapped || win->isHidden())
+		if ((win->workspaceID() != ws) || !win->m_isMapped || win->isHidden())
 			continue;
 		onWindowCreated(win);
 	}

--- a/workspaceLayout.hpp
+++ b/workspaceLayout.hpp
@@ -18,81 +18,75 @@
 #include "globals.hpp"
 
 struct SWorkspaceLayoutWindowData {
-	PHLWINDOWREF pWindow;
-	int workspaceID = -1;
-    bool operator==(const SWorkspaceLayoutWindowData& rhs) const {
+    PHLWINDOWREF pWindow;
+    int          workspaceID = -1;
+    bool         operator==(const SWorkspaceLayoutWindowData& rhs) const {
         return pWindow.lock() == rhs.pWindow.lock();
     }
 };
 
-
 struct SWorkspaceLayoutData {
-    int                workspaceID = -1;
-    IHyprLayout *      layout = nullptr;
-	  IHyprLayout *      previousLayout = nullptr;
-		bool							 isDefault = false;
+    int          workspaceID    = -1;
+    IHyprLayout* layout         = nullptr;
+    IHyprLayout* previousLayout = nullptr;
+    bool         isDefault      = false;
 
-
-    bool               operator==(const SWorkspaceLayoutData& rhs) const {
+    bool         operator==(const SWorkspaceLayoutData& rhs) const {
         return workspaceID == rhs.workspaceID;
     }
 };
 
-
-
 class CWorkspaceLayout : public IHyprLayout {
   public:
-    virtual void onEnable();
-    virtual void onDisable();
-    virtual void onWindowCreated(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
-    virtual void onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
-    virtual void onWindowCreatedFloating(PHLWINDOW);
-    virtual bool isWindowTiled(PHLWINDOW);
-    virtual void onWindowRemoved(PHLWINDOW);
-    virtual void onWindowRemovedTiling(PHLWINDOW);
-    virtual void onWindowRemovedFloating(PHLWINDOW);
-    virtual void recalculateMonitor(const MONITORID&);
-    virtual void recalculateWindow(PHLWINDOW);
-    virtual void changeWindowFloatingMode(PHLWINDOW);
-    virtual void onBeginDragWindow();
-    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
-    virtual void moveActiveWindow(const Vector2D&, PHLWINDOW pWindow = nullptr);
-    virtual void onEndDragWindow();
-    virtual void onMouseMove(const Vector2D&);
-    virtual void fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE);
-    virtual std::any layoutMessage(SLayoutMessageHeader, std::string);
+    virtual void                     onEnable();
+    virtual void                     onDisable();
+    virtual void                     onWindowCreated(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
+    virtual void                     onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
+    virtual void                     onWindowCreatedFloating(PHLWINDOW);
+    virtual bool                     isWindowTiled(PHLWINDOW);
+    virtual void                     onWindowRemoved(PHLWINDOW);
+    virtual void                     onWindowRemovedTiling(PHLWINDOW);
+    virtual void                     onWindowRemovedFloating(PHLWINDOW);
+    virtual void                     recalculateMonitor(const MONITORID&);
+    virtual void                     recalculateWindow(PHLWINDOW);
+    virtual void                     changeWindowFloatingMode(PHLWINDOW);
+    virtual void                     onBeginDragWindow();
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
+    virtual void                     moveActiveWindow(const Vector2D&, PHLWINDOW pWindow = nullptr);
+    virtual void                     onEndDragWindow();
+    virtual void                     onMouseMove(const Vector2D&);
+    virtual void                     fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE);
+    virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW);
-    virtual void switchWindows(PHLWINDOW, PHLWINDOW);
-    virtual void moveWindowTo(PHLWINDOW, const std::string& direction, bool silent);
-    virtual void alterSplitRatio(PHLWINDOW, float, bool exact = false);
-    virtual std::string getLayoutName();
-    virtual PHLWINDOW getNextWindowCandidate(PHLWINDOW);
-    virtual void onWindowFocusChange(PHLWINDOW);
-    virtual void replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
-    virtual bool isWindowReachable(PHLWINDOW);
-    virtual void bringWindowToTop(PHLWINDOW);
-    virtual void requestFocusForWindow(PHLWINDOW);
-		virtual Vector2D predictSizeForNewWindowTiled();
+    virtual void                     switchWindows(PHLWINDOW, PHLWINDOW);
+    virtual void                     moveWindowTo(PHLWINDOW, const std::string& direction, bool silent);
+    virtual void                     alterSplitRatio(PHLWINDOW, float, bool exact = false);
+    virtual std::string              getLayoutName();
+    virtual PHLWINDOW                getNextWindowCandidate(PHLWINDOW);
+    virtual void                     onWindowFocusChange(PHLWINDOW);
+    virtual void                     replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
+    virtual bool                     isWindowReachable(PHLWINDOW);
+    virtual void                     bringWindowToTop(PHLWINDOW);
+    virtual void                     requestFocusForWindow(PHLWINDOW);
+    virtual Vector2D                 predictSizeForNewWindowTiled();
 
-		void setDefaultLayout(std::string name);
-		void clearLayoutMaps();
-		void setupWorkspace(PHLWORKSPACE pWorkspace);
-		void         setupLayoutList();
-
-
+    void                             setDefaultLayout(std::string name);
+    void                             clearLayoutMaps();
+    void                             setupWorkspace(PHLWORKSPACE pWorkspace);
+    void                             setupLayoutList();
 
   private:
-		std::vector<SWorkspaceLayoutData> m_vWorkspacesData;
-		std::list<SWorkspaceLayoutWindowData> m_vWorkspaceWindowData;
-    SWorkspaceLayoutWindowData* getDataFromWindow(PHLWINDOW, bool create=true);
-		IHyprLayout *getLayoutForWorkspace(const int& ws);
-    IHyprLayout *getPreviousLayoutForWorkspace(const int &ws);
-		void setLayoutForWorkspace(IHyprLayout *layout, PHLWORKSPACE pWorkspace, bool isDefault);
-		void setLayoutForWorkspace(IHyprLayout *layout, const int& ws, bool isDefault = false);
-		IHyprLayout *findUserLayoutForWorkspace(PHLWORKSPACE pWorkspace);
-		IHyprLayout *getLayoutByName(const std::string& name);
-		IHyprLayout												*m_pDefaultLayout = nullptr;
-    std::vector<IHyprLayout *> m_vLayoutList;
+    std::vector<SWorkspaceLayoutData>     m_vWorkspacesData;
+    std::list<SWorkspaceLayoutWindowData> m_vWorkspaceWindowData;
+    SWorkspaceLayoutWindowData*           getDataFromWindow(PHLWINDOW, bool create = true);
+    IHyprLayout*                          getLayoutForWorkspace(const int& ws);
+    IHyprLayout*                          getPreviousLayoutForWorkspace(const int& ws);
+    void                                  setLayoutForWorkspace(IHyprLayout* layout, PHLWORKSPACE pWorkspace, bool isDefault);
+    void                                  setLayoutForWorkspace(IHyprLayout* layout, const int& ws, bool isDefault = false);
+    IHyprLayout*                          findUserLayoutForWorkspace(PHLWORKSPACE pWorkspace);
+    IHyprLayout*                          getLayoutByName(const std::string& name);
+    IHyprLayout*                          m_pDefaultLayout = nullptr;
+    std::vector<IHyprLayout*>             m_vLayoutList;
 
     friend struct SWorkspaceLayoutData;
     friend struct SWorkspaceLayoutWindowData;


### PR DESCRIPTION
fixes the build again with the new name changes merged (see https://github.com/hyprwm/Hyprland/commit/21184404885cf61f7c10d2eb749478ef6b035dd2)

What's bothered me here for a longer time was also that the code formatting was really all over the place so I copied over the `.clang-format` from hyprNStack, and formatted the code here. But I can also revert that commit again if you don't want it.