### PR TITLE
we are free

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Workspace and monitor specific window layouts for Hyprland 
 
+> [!IMPORTANT]
+> Starting with version `0.54.0`, Hyprland has inbuilt support for per-workspace layouts, making this plugin obsolete. For more info, have a look at the [example](https://wiki.hypr.land/Configuring/Uncommon-tips--tricks/#per-workspace-layouts) in the Hyprland wiki.
 
 Do you wish you could run different window tiling layouts on individual workspaces? This plugin makes it possible!
-
-> [!NOTE]
-> If you would like to see per-workspace layouts implemented in hyprland itself, please add a reaction (👍) to [the corresponding issue](https://github.com/hyprwm/Hyprland/issues/10293).
 
 ## Using hyprpm, Hyprland's official plugin manager (recommended)
 1. Run `hyprpm add https://github.com/zakk4223/hyprWorkspaceLayouts` and wait for hyprpm to build the plugin.


### PR DESCRIPTION
I still can't believe I am saying this, but with https://github.com/hyprwm/Hyprland/pull/12890 Hyprland has rewritten the layout system from scratch and thus finally has inbuilt per-workspace layout support. I've updated the text in the readme to no longer point to the issue but to an [example](https://wiki.hypr.land/Configuring/Uncommon-tips--tricks/#per-workspace-layouts) in the hyprland wiki instead (or [here](https://github.com/hyprwm/hyprland-wiki/blob/main/content/Configuring/Uncommon-tips-%26-tricks.md#per-workspace-layouts) on github, not yet deployed at the time of writing). You can probably also archive the repository now unless you plan to continue supporting older versions.

Thanks a lot for creating this plugin in the first place as it was an indispensable part of my workflow until now. So long and thanks for all the fish!